### PR TITLE
Migration models

### DIFF
--- a/api.go
+++ b/api.go
@@ -507,6 +507,7 @@ func unmarshalHTMLContent(r Receiver) (h *HTMLContent) {
 	h.ContentID = r.ContentID
 	h.PublicationDate = r.PublicationDate
 	h.Code = r.Code
+	h.TeaserTitle = getTeaserTitle(&r)
 	h.NavContext = r.NavContext
 	h.AnalyticsCategory = r.AnalyticsCategory
 	h.AdvertisingCategory = r.AdvertisingCategory

--- a/api.go
+++ b/api.go
@@ -507,6 +507,7 @@ func unmarshalHTMLContent(r Receiver) (h *HTMLContent) {
 	h.ContentID = r.ContentID
 	h.PublicationDate = r.PublicationDate
 	h.Code = r.Code
+	h.URL = r.URL
 	h.TeaserTitle = getTeaserTitle(&r)
 	h.NavContext = r.NavContext
 	h.AnalyticsCategory = r.AnalyticsCategory

--- a/datamap/article.go
+++ b/datamap/article.go
@@ -1,0 +1,45 @@
+package datamap
+
+// Article represents an IB article
+type Article struct {
+	fullBase
+
+	Dateline     string `json:"author_location"`
+	Text         string `json:"article_text"`
+	Subheadline  string `json:"subheadline"`
+	RelatedMedia []Item `json:"related_media"`
+}
+
+func (a *Article) GetType() ItemType {
+	return ArticleType
+}
+
+func (a *Article) GetContentID() int {
+	return a.ContentID
+}
+
+func (a *Article) GetTeaserTitle() string {
+	return a.TeaserTitle
+}
+
+func (a *Article) GetTeaserText() string {
+	return a.TeaserText
+}
+
+func (a *Article) GetPublicationDate() string {
+	return a.PublicationDate
+}
+
+func (a *Article) Unmarshal(r *Receiver) error {
+	if err := a.unmarshalFullBase(r); err != nil {
+		return err
+	}
+
+	a.Dateline = r.Dateline
+	a.Text = r.ArticleText
+	a.Subheadline = r.Subheadline
+	relatedMedia, err := unmarshalItems(r.RelatedMedia)
+	a.RelatedMedia = relatedMedia
+
+	return err
+}

--- a/datamap/audio.go
+++ b/datamap/audio.go
@@ -1,0 +1,43 @@
+package datamap
+
+// Audio represents an audio clip
+type Audio struct {
+	fullBase
+
+	ExternalID  string `json:"external_id"`
+	Subheadline string `json:"subheadline"`
+	StreamURL   string `json:"m3u8"`
+	ShowAds     bool   `json:"show_ads"`
+}
+
+func (a *Audio) GetType() ItemType {
+	return AudioType
+}
+
+func (a *Audio) GetContentID() int {
+	return a.ContentID
+}
+
+func (a *Audio) GetTeaserTitle() string {
+	return a.TeaserTitle
+}
+
+func (a *Audio) GetTeaserText() string {
+	return a.TeaserText
+}
+
+func (a *Audio) GetPublicationDate() string {
+	return a.PublicationDate
+}
+
+func (a *Audio) Unmarshal(r *Receiver) error {
+	if err := a.unmarshalFullBase(r); err != nil {
+		return err
+	}
+
+	a.ExternalID = r.ExternalID
+	a.Subheadline = r.Subheadline
+	a.StreamURL = r.StreamURL
+
+	return nil
+}

--- a/datamap/category.go
+++ b/datamap/category.go
@@ -1,0 +1,38 @@
+package datamap
+
+type Category struct {
+	bareBase
+
+	Identifier string              `json:"identifier"`
+	Children   []Category          `json:"children"`
+	Settings   []map[string]string `json:"settings"`
+}
+
+func (c *Category) GetType() ItemType {
+	return CategoryType
+}
+
+func (c *Category) GetContentID() int {
+	return c.ContentID
+}
+
+func (c *Category) GetTeaserTitle() string {
+	return ""
+}
+
+func (c *Category) GetTeaserText() string {
+	return ""
+}
+
+func (c *Category) GetPublicationDate() string {
+	return c.PublicationDate
+}
+
+func (c *Category) Unmarshal(r *Receiver) error {
+	c.unmarshalBareBase(r)
+	c.Identifier = r.Identifier
+	c.Children = r.Children
+	c.Settings = r.Settings
+
+	return nil
+}

--- a/datamap/closings.go
+++ b/datamap/closings.go
@@ -1,0 +1,32 @@
+package datamap
+
+type ClosingsFilter string
+
+const (
+	ClosingsAll    ClosingsFilter = "all"
+	ClosingsClosed ClosingsFilter = "closed"
+	ClosingsCount  ClosingsFilter = "count"
+	ClosingsInst   ClosingsFilter = "institution"
+)
+
+type ClosingsResponse struct {
+	Count              ClsCount                    `json:"count"`
+	Institutions       map[string][]ClsInstitution `json:"institutions,omitempty"`
+	ClosedInstitutions map[string][]ClsInstitution `json:"closed_institutions,omitempty"`
+	Institution        ClsInstitution              `json:"institution"`
+}
+
+type ClsCount struct {
+	Total           int   `json:"total"`
+	PublicationDate int64 `json:"publication_date"`
+}
+
+type ClsInstitution struct {
+	Name            string `json:"name"`
+	PublicationDate int64  `json:"publication_date"`
+	City            string `json:"city"`
+	County          string `json:"county"`
+	State           string `json:"state"`
+	ProviderID      string `json:"provider_id"`
+	Status          string `json:"status"`
+}

--- a/datamap/collection.go
+++ b/datamap/collection.go
@@ -1,0 +1,56 @@
+package datamap
+
+type Collection struct {
+	fullBase
+
+	Name            string              `json:"collection_name"`
+	ExternalContent string              `json:"external_content"`
+	Dynamic         bool                `json:"dynamic"`
+	ViewType        string              `json:"view_type"`
+	Items           []Collection        `json:"items"`
+	StartIndex      int                 `json:"start_index"`
+	TotalCount      int                 `json:"total_count"`
+	Settings        []map[string]string `json:"settings"`
+}
+
+func (c *Collection) GetType() ItemType {
+	return CollectionType
+}
+
+func (c *Collection) GetContentID() int {
+	return c.ContentID
+}
+
+func (c *Collection) GetTeaserTitle() string {
+	return c.TeaserTitle
+}
+
+func (c *Collection) GetTeaserText() string {
+	return c.TeaserText
+}
+
+func (c *Collection) GetPublicationDate() string {
+	return c.PublicationDate
+}
+
+func (c *Collection) Unmarshal(r *Receiver) error {
+	if err := c.unmarshalFullBase(r); err != nil {
+		return err
+	}
+
+	c.Name = r.CollectionName
+	c.ExternalContent = r.ExternalContent
+	c.Dynamic = r.Dynamic
+	c.ViewType = r.ViewType
+	c.StartIndex = r.StartIndex
+	c.TotalCount = r.TotalCount
+	c.Settings = r.Settings
+
+	if collections, err := unmarshalCollections(r.Items); err != nil {
+		return err
+	} else {
+		c.Items = collections
+	}
+
+	return nil
+}

--- a/datamap/copyright.go
+++ b/datamap/copyright.go
@@ -1,0 +1,40 @@
+package datamap
+
+//Copyright type
+type Copyright struct {
+	fullBase
+
+	Name string `json:"name"`
+	Text string `json:"text"`
+}
+
+func (c *Copyright) GetType() ItemType {
+	return CollectionType
+}
+
+func (c *Copyright) GetContentID() int {
+	return c.ContentID
+}
+
+func (c *Copyright) GetTeaserTitle() string {
+	return c.TeaserTitle
+}
+
+func (c *Copyright) GetTeaserText() string {
+	return c.TeaserText
+}
+
+func (c *Copyright) GetPublicationDate() string {
+	return c.PublicationDate
+}
+
+func (c *Copyright) Unmarshal(r *Receiver) error {
+	if err := c.unmarshalFullBase(r); err != nil {
+		return err
+	}
+
+	c.Name = r.Name
+	c.Text = r.Text
+
+	return nil
+}

--- a/datamap/doc.go
+++ b/datamap/doc.go
@@ -10,11 +10,12 @@ package datamap
 	All shared common properties are abstracted in two internal types:
 	- bareBase
 	- fullBase
-	and need to be unmarshal by its respective methods to augment the
-	current struct with the fields. Note that the json tags are used
-	as a documentation reference instead of a decoder hint, since the
-	properties inside the specialized struct may have its name
-	changed by the context. (standard set by someone else thee I followed)
+	and needs to be unmarshal by its respective methods. Note that the json tags
+	are used also as a documentation reference than just a decoder hint,
+	since the properties inside the specialized struct may have its name
+	changed by the context. (standard set by someone else and I followed)
+	So, when navigating around, look at the json field to know exactly
+	what that property means.
 
 	If a struct uses some substruct inside it (namespaced as the main
 	struct), it can be found in the same file of the main struct.
@@ -25,7 +26,8 @@ package datamap
 	backward compatibility's sake, but they're all "marked" with
 	a comment. The idea is to share the same model struct between
 	the migration and the goib api. So it's easy to  just change
-	the endpoint later.
+	the endpoint later. Is that turn out to be true, I'll remove
+	the backward compatibility thing, don't worry.
 
 	There are some structs inside the receiver.go file that the
 	goib API uses but are not present in the migration data

--- a/datamap/doc.go
+++ b/datamap/doc.go
@@ -1,0 +1,37 @@
+package datamap
+
+/*
+	This package holds the models that map the Lakana structure to
+	MediaOS structure. Its main structure is listed under Receiver,
+	that is used as a union struct of all struct types to enable
+	an easy JSON conversion.
+
+	NOTES: (read this before change anything!)
+	All shared common properties are abstracted in two internal types:
+	- bareBase
+	- fullBase
+	and need to be unmarshal by its respective methods to augment the
+	current struct with the fields. Note that the json tags are used
+	as a documentation reference instead of a decoder hint, since the
+	properties inside the specialized struct may have its name
+	changed by the context. (standard set by someone else thee I followed)
+
+	If a struct uses some substruct inside it (namespaced as the main
+	struct), it can be found in the same file of the main struct.
+	e.g.: ImageURL can be found inside image.go file
+	      VideoFlavor can be found inside video.go file
+
+	There are some properties in structs placed there just for
+	backward compatibility's sake, but they're all "marked" with
+	a comment. The idea is to share the same model struct between
+	the migration and the goib api. So it's easy to  just change
+	the endpoint later.
+
+	There are some structs inside the receiver.go file that the
+	goib API uses but are not present in the migration data
+	structure. So, they're not separated in specific files as
+	they are seen as subtypes for now. The only exception for
+	that is Closings (that had a more complex layout and got
+	separated in favor of a better organization)
+
+*/

--- a/datamap/download_file.go
+++ b/datamap/download_file.go
@@ -1,0 +1,38 @@
+package datamap
+
+//DownloadFile represents a link to download a file
+type DownloadFile struct {
+	fullBase
+
+	LinkText string `json:"link_text"`
+}
+
+func (d *DownloadFile) GetType() ItemType {
+	return DownloadFileType
+}
+
+func (d *DownloadFile) GetContentID() int {
+	return d.ContentID
+}
+
+func (d *DownloadFile) GetTeaserTitle() string {
+	return d.TeaserTitle
+}
+
+func (d *DownloadFile) GetTeaserText() string {
+	return d.TeaserText
+}
+
+func (d *DownloadFile) GetPublicationDate() string {
+	return d.PublicationDate
+}
+
+func (d *DownloadFile) Unmarshal(r *Receiver) error {
+	if err := d.unmarshalFullBase(r); err != nil {
+		return err
+	}
+
+	d.LinkText = r.LinkText
+
+	return nil
+}

--- a/datamap/external_content.go
+++ b/datamap/external_content.go
@@ -1,0 +1,44 @@
+package datamap
+
+// ExternalContent represents an external content object
+type ExternalContent struct {
+	fullBase
+
+	Content         string `json:"external_content"`
+	Transformed     string `json:"transformed_external_content"`
+	TransformerType string `json:"transformer_type"`
+	LinkText        string `string:"link_text"`
+}
+
+func (e *ExternalContent) GetType() ItemType {
+	return ExternalContentType
+}
+
+func (e *ExternalContent) GetContentID() int {
+	return e.ContentID
+}
+
+func (e *ExternalContent) GetTeaserTitle() string {
+	return e.TeaserTitle
+}
+
+func (e *ExternalContent) GetTeaserText() string {
+	return e.TeaserText
+}
+
+func (e *ExternalContent) GetPublicationDate() string {
+	return e.PublicationDate
+}
+
+func (e *ExternalContent) Unmarshal(r *Receiver) error {
+	if err := e.unmarshalFullBase(r); err != nil {
+		return err
+	}
+
+	e.Content = r.ExternalContent
+	e.Transformed = r.TransformedExternalContent
+	e.TransformerType = r.TransformedType
+	e.LinkText = e.LinkText
+
+	return nil
+}

--- a/datamap/external_link.go
+++ b/datamap/external_link.go
@@ -1,0 +1,37 @@
+package datamap
+
+type ExternalLink struct {
+	fullBase
+
+	LinkText string `json:"link_text"`
+}
+
+func (e *ExternalLink) GetType() ItemType {
+	return ExternalLinkType
+}
+
+func (e *ExternalLink) GetContentID() int {
+	return e.ContentID
+}
+
+func (e *ExternalLink) GetTeaserTitle() string {
+	return e.TeaserTitle
+}
+
+func (e *ExternalLink) GetTeaserText() string {
+	return e.TeaserText
+}
+
+func (e *ExternalLink) GetPublicationDate() string {
+	return e.PublicationDate
+}
+
+func (e *ExternalLink) Unmarshal(r *Receiver) error {
+	if err := e.unmarshalFullBase(r); err != nil {
+		return err
+	}
+
+	e.LinkText = e.LinkText
+
+	return nil
+}

--- a/datamap/gallery.go
+++ b/datamap/gallery.go
@@ -1,0 +1,40 @@
+package datamap
+
+type Gallery struct {
+	fullBase
+
+	Subheadline string `json:"subheadline"`
+	Items       []Item `json:"items"` //IMAGES
+}
+
+func (g *Gallery) GetType() ItemType {
+	return GalleryType
+}
+
+func (g *Gallery) GetContentID() int {
+	return g.ContentID
+}
+
+func (g *Gallery) GetTeaserTitle() string {
+	return g.TeaserTitle
+}
+
+func (g *Gallery) GetTeaserText() string {
+	return g.TeaserText
+}
+
+func (g *Gallery) GetPublicationDate() string {
+	return g.PublicationDate
+}
+
+func (g *Gallery) Unmarshal(r *Receiver) error {
+	if err := g.unmarshalFullBase(r); err != nil {
+		return err
+	}
+
+	g.Subheadline = r.Subheadline
+	items, err := unmarshalItems(r.Items)
+	g.Items = items
+
+	return err
+}

--- a/datamap/image.go
+++ b/datamap/image.go
@@ -1,0 +1,53 @@
+package datamap
+
+// Image represents an IB image content piece
+type Image struct {
+	fullBase
+
+	Caption string     `json:"caption"`
+	URLs    []ImageURL `json:"urls"`
+	//backward compatibility
+	AltText string `json:"alt_text"`
+}
+
+func (i *Image) GetType() ItemType {
+	return ImageType
+}
+
+func (i *Image) GetContentID() int {
+	return i.ContentID
+}
+
+func (i *Image) GetTeaserTitle() string {
+	return i.TeaserTitle
+}
+
+func (i *Image) GetTeaserText() string {
+	return i.TeaserText
+}
+
+func (i *Image) GetPublicationDate() string {
+	return i.PublicationDate
+}
+
+func (i *Image) Unmarshal(r *Receiver) error {
+	if err := i.unmarshalFullBase(r); err != nil {
+		return err
+	}
+
+	i.Caption = r.Caption
+	i.URLs = r.URLs
+
+	i.AltText = r.AltText
+
+	return nil
+}
+
+// ImageURL is a URL flavor for an image
+type ImageURL struct {
+	Version string `json:"version"`
+	Height  int    `json:"height"`
+	Width   int    `json:"width"`
+	URL     string `json:"url"`
+	Mime    string `json:"mime"`
+}

--- a/datamap/item.go
+++ b/datamap/item.go
@@ -1,0 +1,68 @@
+package datamap
+
+// ItemType is the type of content encapsulated by the object
+type ItemType string
+
+const (
+	//Migration item types
+	// ArticleType item type
+	ArticleType ItemType = "ARTICLE"
+	// AudioType item type
+	AudioType ItemType = "AUDIO"
+	// CategoryType item type
+	CategoryType ItemType = "CATEGORY"
+	// CollectionType item type
+	CollectionType ItemType = "COLLECTION"
+	// CopyrightType item type
+	CopyrightType ItemType = "COPYRIGHT"
+	// DownloadFileType item type
+	DownloadFileType ItemType = "DOWNLOAD_FILE"
+	// ExternalContentType external content item type
+	ExternalContentType ItemType = "EXTERNAL_CONTENT"
+	// ExternalLinkType external content item type
+	ExternalLinkType ItemType = "EXTERNAL_LINK"
+	// GalleryType item type
+	GalleryType ItemType = "GALLERY"
+	// ImageType item type
+	ImageType ItemType = "IMAGE"
+	// LiveStreamType item type
+	LiveStreamType ItemType = "LIVESTREAM"
+	// LiveVideoType item type
+	LiveVideoType ItemType = "LIVEVIDEO"
+	// PersonType Person (AKA Author) item type
+	PersonType ItemType = "PERSON"
+	// VideoType item type
+	VideoType ItemType = "VIDEO"
+
+	//API item types
+	// SearchType item type
+	SearchType ItemType = "SEARCH"
+	// MapType item type
+	MapType ItemType = "MAP"
+	// ClosingsType item type
+	ClosingsType ItemType = "CLOSINGS"
+	// HTMLType HTML item type
+	HTMLType ItemType = "HTML"
+	// TeaserType teasy teasy tease.
+	TeaserType ItemType = "TEASER"
+	// SettingsType is someone's idiot idea of a joke
+	SettingsType ItemType = ""
+)
+
+// Item is the base type of all items. It is not used outside the IB package, as
+// we return full objects, partially populated
+type Item interface {
+	GetType() ItemType
+	GetContentID() int
+	GetTeaserTitle() string
+	GetTeaserText() string
+	GetPublicationDate() string
+	Unmarshal(r *Receiver) error
+	//NOTE: Despite StationName added in the types
+	//      I don't know if this model will be goib compatible
+	//		because of the GetPublicationDate type.
+	//		so, I'll have to check with an API dev if
+	//		all that makes sense
+	//GetStationName() string
+	//SetStationName(string)
+}

--- a/datamap/livestream.go
+++ b/datamap/livestream.go
@@ -1,0 +1,54 @@
+package datamap
+
+//Live Stream is a stream that can be used by the Live Video
+type LiveStream struct {
+	fullBase
+
+	ExternalID       string `json:"external_id"`
+	PrimaryURL       string `json:"primaryUrl"`
+	BackupURL        string `json:"backupUrl"`
+	Name             string `json:"streamName"`
+	PrimaryEncoder   string `json:"primaryEncoder"`
+	SecondaryEncoder string `json:"secondaryEncoder"`
+	UserName         string `json:"userName"`
+	Password         string `json:"password"`
+	Transcoded       bool   `json:"streamTranscoded"`
+}
+
+func (l *LiveStream) GetType() ItemType {
+	return LiveStreamType
+}
+
+func (l *LiveStream) GetContentID() int {
+	return l.ContentID
+}
+
+func (l *LiveStream) GetTeaserTitle() string {
+	return l.TeaserTitle
+}
+
+func (l *LiveStream) GetTeaserText() string {
+	return l.TeaserText
+}
+
+func (l *LiveStream) GetPublicationDate() string {
+	return l.PublicationDate
+}
+
+func (l *LiveStream) Unmarshal(r *Receiver) error {
+	if err := l.unmarshalFullBase(r); err != nil {
+		return err
+	}
+
+	l.ExternalID = r.ExternalID
+	l.PrimaryURL = r.PrimaryURL
+	l.BackupURL = r.BackupURL
+	l.Name = r.StreamName
+	l.PrimaryEncoder = r.PrimaryEncoder
+	l.SecondaryEncoder = r.SecondaryEncoder
+	l.UserName = r.UserName
+	l.Password = r.Password
+	l.Transcoded = r.StreamTranscoded
+
+	return nil
+}

--- a/datamap/livevideo.go
+++ b/datamap/livevideo.go
@@ -1,0 +1,50 @@
+package datamap
+
+// LiveVideo represents a stream
+type LiveVideo struct {
+	fullBase
+
+	ExternalID  string     `json:"external_id"`
+	Subheadline string     `json:"subheadline"`
+	LiveStream  LiveStream `json:"livestream"`
+	StreamURL   string     `json:"m3u8"`
+	ShowAds     bool       `json:"show_ads"`
+	// backward compatibility
+	Stream string `json:"stream"`
+}
+
+func (l *LiveVideo) GetType() ItemType {
+	return LiveVideoType
+}
+
+func (l *LiveVideo) GetContentID() int {
+	return l.ContentID
+}
+
+func (l *LiveVideo) GetTeaserTitle() string {
+	return l.TeaserTitle
+}
+
+func (l *LiveVideo) GetTeaserText() string {
+	return l.TeaserText
+}
+
+func (l *LiveVideo) GetPublicationDate() string {
+	return l.PublicationDate
+}
+
+func (l *LiveVideo) Unmarshal(r *Receiver) error {
+	if err := l.unmarshalFullBase(r); err != nil {
+		return err
+	}
+
+	l.ExternalID = r.ExternalID
+	l.Subheadline = r.Subheadline
+	l.LiveStream = r.LiveStream
+	l.StreamURL = r.StreamURL
+	l.ShowAds = r.ShowAds
+
+	l.Stream = r.Stream
+
+	return nil
+}

--- a/datamap/person.go
+++ b/datamap/person.go
@@ -1,0 +1,64 @@
+package datamap
+
+// Person represents an IB person
+type Person struct {
+	fullBase
+
+	Blurb         string `json:"teaser_text"`
+	FullName      string `json:"full_name"`
+	Email         string `json:"email"`
+	Bio           string `json:"biography"`
+	Photo         Image  `json:"photo"`
+	FacebookURL   string `json:"facebook_url"`
+	GooglePlusURL string `json:"google_plus_url"`
+	TwitterURL    string `json:"twitter_url"`
+	// backward compatibility
+	FacebookUsername string `json:"facebook_username"`
+	FacebookUID      string `json:"facebook_uid"`
+	TwitterUsername  string `json:"twitter_username"`
+	GPlusUID         string `json:"gplus_uid"`
+	StoriesCOID      int    `json:"recent_stories"`
+}
+
+func (p *Person) GetType() ItemType {
+	return PersonType
+}
+
+func (p *Person) GetContentID() int {
+	return p.ContentID
+}
+
+func (p *Person) GetTeaserTitle() string {
+	return p.FullName
+}
+
+func (p *Person) GetTeaserText() string {
+	return p.Blurb
+}
+
+func (p *Person) GetPublicationDate() string {
+	return p.PublicationDate
+}
+
+func (p *Person) Unmarshal(r *Receiver) error {
+	if err := p.unmarshalFullBase(r); err != nil {
+		return err
+	}
+
+	p.Blurb = r.TeaserText
+	p.FullName = r.FullName
+	p.Email = r.Email
+	p.Bio = r.Bio
+	p.Photo = r.Photo
+	p.FacebookURL = r.FacebookURL
+	p.GooglePlusURL = r.GooglePlusURL
+	p.TwitterURL = r.TwitterURL
+
+	p.FacebookUsername = r.FacebookUsername
+	p.FacebookUID = r.FacebookUID
+	p.TwitterUsername = r.TwitterUsername
+	p.GPlusUID = r.GPlusUID
+	p.StoriesCOID = r.StoriesCOID
+
+	return nil
+}

--- a/datamap/receiver.go
+++ b/datamap/receiver.go
@@ -1,0 +1,473 @@
+package datamap
+
+import (
+	"fmt"
+)
+
+// Receiver captures a type-agnostic representation of an API response as a
+// step in processing a response. Its fields are a superset of all content fields,
+// so any type can be captured and derived from this struct.
+// This object should not be used outside of the IB API classes. It is exposed
+// only to facilitate JSON unmarshalling.
+//
+// - Text was article_text but now there are 2 fields (article_text and only text)
+//   so they got separated inside Receiver
+// - maybe the outer publication date is now a string
+//   and only the inner kept as integers (timestamp) what now?
+type Receiver struct {
+	Type                ItemType      `json:"type"`
+	Hash                string        `json:"hash"`
+	ContentID           int           `json:"content_id"`
+	ContentName         string        `json:"content_name"`
+	Title               string        `json:"title"`
+	PublicationDate     string        `json:"publication_date"`
+	CreationDate        string        `json:"creation_date"`
+	NavContext          []string      `json:"navigation_context"`
+	ValidFrom           string        `json:"valid_from"`
+	ValidTo             string        `json:"valid_to"`
+	AnalyticsCategory   string        `json:"analytics_category"`
+	AdvertisingCategory string        `json:"advertising_category"`
+	TeaserTitle         string        `json:"teaser_title"`
+	TeaserText          string        `json:"teaser_text"`
+	TeaserImage         string        `json:"teaser_image"`
+	Author              string        `json:"author"`
+	Authors             []Person      `json:"author_objects"`
+	EditorialComment    string        `json:"editorial_comment"`
+	Copyright           string        `json:"copyright"`
+	Copyrights          []Copyright   `json:"copyright_objects"`
+	Media               []Receiver    `json:"media"`
+	CanonicalURL        string        `json:"canonical_url"`
+	URL                 string        `json:"url"`
+	Categories          []interface{} `json:"categories"`
+	Struct              []interface{} `json:"struct"`
+	CommentingEnabled   bool          `json:"commenting_enabled"`
+	NoFollow            bool          `json:"no_follow"`
+	NotSearchable       bool          `json:"not_searchable"`
+	Period              string        `json:"period"`
+	Keywords            string        `json:"keywords"`
+
+	//shared at least by 2 structs
+	ExternalID      string              `json:"external_id"`
+	ExternalContent string              `json:"external_content"`
+	Subheadline     string              `json:"subheadline"`
+	StreamURL       string              `json:"m3u8"`
+	ShowAds         bool                `json:"show_ads"`
+	Settings        []map[string]string `json:"settings"`
+	StartIndex      int                 `json:"start_index"`
+	LinkText        string              `json:"link_text"`
+	Items           []Receiver          `json:"items"`
+	Caption         string              `json:"caption"`
+
+	//Article only
+	Dateline     string     `json:"author_location"`
+	ArticleText  string     `json:"article_text"`
+	RelatedMedia []Receiver `json:"related_media"`
+
+	//Category only
+	Identifier string     `json:"identifier"`
+	Children   []Category `json:"children"`
+
+	//Collection only
+	CollectionName string `json:"collection_name"`
+	Dynamic        bool   `json:"dynamic"`
+	ViewType       string `json:"view_type"`
+	TotalCount     int    `json:"total_count"`
+
+	//Copyright only
+	Name string `json:"name"`
+	Text string `json:"text"`
+
+	//ExternalContent only
+	TransformedExternalContent string `json:"transformed_external_content"`
+	TransformedType            string `json:"transformed_type"`
+
+	//Image only
+	URLs    []ImageURL `json:"urls"`
+	AltText string     `json:"alt_text"`
+
+	//LiveStream only
+	PrimaryURL       string `json:"primaryUrl"`
+	BackupURL        string `json:"backupUrl"`
+	StreamName       string `json:"streamName"`
+	PrimaryEncoder   string `json:"primaryEncoder"`
+	SecondaryEncoder string `json:"secondaryEncoder"`
+	UserName         string `json:"userName"`
+	Password         string `json:"password"`
+	StreamTranscoded bool   `json:"streamTranscoded"`
+
+	//LiveVideo only
+	LiveStream LiveStream `json:"livestream"`
+	Stream     string     `json:"stream"`
+
+	//Person only
+	FullName         string `json:"full_name"`
+	Email            string `json:"email"`
+	Bio              string `json:"biography"`
+	Photo            Image  `json:"photo"`
+	FacebookURL      string `json:"facebook_url"`
+	GooglePlusURL    string `json:"google_plus_url"`
+	TwitterURL       string `json:"twitter_url"`
+	FacebookUsername string `json:"facebook_username"`
+	FacebookUID      string `json:"facebook_uid"`
+	TwitterUsername  string `json:"twitter_username"`
+	GPlusUID         string `json:"gplus_uid"`
+	StoriesCOID      int    `json:"recent_stories"`
+
+	//Video only
+	Flavors        []VideoFlavor `json:"flavors"`
+	SharingEnabled bool          `json:"sharing_enabled"`
+
+	//MODELS WITH NO SPECIFIC PROPERTIES
+	//Audio
+	//DownloadFile
+	//ExternalLink
+
+	//receiver internal submodules
+	Code           string            `json:"code"`
+	StaticMap      string            `json:"static_map"`
+	InteractiveMap string            `json:"interactive_map"`
+	Target         *Receiver         `json:"target"`
+	Captions       map[string]string `json:"captions"` // not from IB, but needed for UnmarshalReceiver()
+}
+
+//Maps the data of Receiver to the specific struct
+func (r *Receiver) Unmarshal() (Item, error) {
+	var item Item
+
+	//maps string type to the correct struct
+	switch r.Type {
+	// migratin types
+	case ArticleType:
+		item = &Article{}
+	case AudioType:
+		item = &Audio{}
+	case CategoryType:
+		item = &Category{}
+	case CollectionType:
+		item = &Collection{}
+	case CopyrightType:
+		item = &Copyright{}
+	case DownloadFileType:
+		item = &DownloadFile{}
+	case ExternalContentType:
+		item = &ExternalContent{}
+	case ExternalLinkType:
+		item = &ExternalLink{}
+	case GalleryType:
+		item = &Gallery{}
+	case ImageType:
+		item = &Image{}
+	case LiveStreamType:
+		item = &LiveStream{}
+	case LiveVideoType:
+		item = &LiveVideo{}
+	case PersonType:
+		item = &Person{}
+	case VideoType:
+		item = &Video{}
+	// api types
+	case SearchType:
+		item = &Collection{}
+	case MapType:
+		item = &Map{}
+	case HTMLType:
+		item = &HTMLContent{}
+	case SettingsType:
+		item = &Settings{}
+	case TeaserType:
+		item = &Teaser{}
+	default:
+		return nil, fmt.Errorf("unknonwn response type for obj %d: %s", r.ContentID, r.Type)
+	}
+
+	err := item.Unmarshal(r)
+
+	return item, err
+}
+
+// this struct here is a list of the common properties shared
+// among all content types
+type bareBase struct {
+	Type                ItemType `json:"type"`
+	Hash                string   `json:"hash"`
+	ContentID           int      `json:"content_id"`
+	ContentName         string   `json:"content_name"`
+	Title               string   `json:"title"`
+	CreationDate        string   `json:"creation_date"`
+	PublicationDate     string   `json:"publication_date"`
+	NavContext          []string `json:"navigation_context"`
+	ValidFrom           string   `json:"valid_from"`
+	ValidTo             string   `json:"valid_to"`
+	AnalyticsCategory   string   `json:"analytics_category"`
+	AdvertisingCategory string   `json:"advertising_category"`
+	StationName         string   `json:"station_name"` //new api adition that seems to be set/get locally
+}
+
+func (b *bareBase) unmarshalBareBase(r *Receiver) {
+	b.Hash = r.Hash
+	b.ContentID = r.ContentID
+	b.ContentName = r.ContentName
+	b.Title = r.Title
+	b.PublicationDate = r.PublicationDate
+	b.CreationDate = r.CreationDate
+	b.NavContext = r.NavContext
+	b.ValidFrom = r.ValidFrom
+	b.ValidTo = r.ValidTo
+	b.AnalyticsCategory = r.AnalyticsCategory
+	b.AdvertisingCategory = r.AdvertisingCategory
+}
+
+// this struct here is a list of the most common properties shared
+// among some content types (the barebone properties are in bareBase)
+type fullBase struct {
+	bareBase
+
+	TeaserTitle       string        `json:"teaser_title"`
+	TeaserText        string        `json:"teaser_text"`
+	TeaserImage       string        `json:"teaser_image"`
+	Author            string        `json:"author"`
+	Authors           []Person      `json:"author_objects"`
+	EditorialComment  string        `json:"editorial_comment"`
+	Copyright         string        `json:"copyright"`
+	Copyrights        []Copyright   `json:"copyright_objects"`
+	Media             []Item        `json:"media"`
+	CanonicalURL      string        `json:"canonical_url"`
+	URL               string        `json:"url"`
+	Categories        []interface{} `json:"categories"`
+	Struct            []interface{} `json:"struct"`
+	CommentingEnabled bool          `json:"commenting_enabled"`
+	NoFollow          bool          `json:"no_follow"`
+	NotSearchable     bool          `json:"not_searchable"`
+	Period            string        `json:"period"`
+	Keywords          string        `json:"keywords"`
+}
+
+func (f *fullBase) unmarshalFullBase(r *Receiver) error {
+	f.unmarshalBareBase(r)
+
+	f.TeaserTitle = getTeaserTitle(r)
+	f.TeaserText = r.TeaserText
+	f.TeaserImage = r.TeaserImage
+	f.Author = r.Author
+	f.Authors = r.Authors
+	f.EditorialComment = r.EditorialComment
+	f.Copyright = r.Copyright
+	f.CanonicalURL = r.CanonicalURL
+	f.URL = r.URL
+	f.Categories = r.Categories
+	f.Struct = r.Struct
+	f.CommentingEnabled = r.CommentingEnabled
+	f.NoFollow = r.NoFollow
+	f.NotSearchable = r.NotSearchable
+	f.Period = r.Period
+	f.Keywords = r.Keywords
+	medias, err := unmarshalItems(r.Media)
+	f.Media = medias
+
+	return err
+}
+
+// Map represents a map
+type Map struct {
+	Type                ItemType `json:"type"`
+	ContentID           int      `json:"content_id"`
+	PublicationDate     string   `json:"publication_date"`
+	TeaserTitle         string   `json:"teaser_title"`
+	TeaserText          string   `json:"teaser_text"`
+	Title               string   `json:"title"`
+	Subheadline         string   `json:"subheadline"`
+	StaticMap           string   `json:"static_map"`
+	InteractiveMap      string   `json:"interactive_map"`
+	CanonicalURL        string   `json:"canonical_url"`
+	URL                 string   `json:"url"`
+	NavContext          []string `json:"navigation_context"`
+	AnalyticsCategory   string   `json:"analytics_category"`
+	AdvertisingCategory string   `json:"advertising_category"`
+	StationName         string   `json:"station_name"`
+}
+
+func (m *Map) GetType() ItemType {
+	return MapType
+}
+
+func (m *Map) GetContentID() int {
+	return m.ContentID
+}
+
+func (m *Map) GetTeaserTitle() string {
+	return m.TeaserTitle
+}
+
+func (m *Map) GetTeaserText() string {
+	return ""
+}
+
+func (m *Map) GetPublicationDate() string {
+	return m.PublicationDate
+}
+
+func (m *Map) Unmarshal(r *Receiver) error {
+	m.Type = r.Type
+	m.ContentID = r.ContentID
+	m.PublicationDate = r.PublicationDate
+	m.Title = r.Title
+	m.Subheadline = r.Subheadline
+	m.TeaserTitle = getTeaserTitle(r)
+	m.TeaserText = r.TeaserText
+	m.StaticMap = r.StaticMap
+	m.InteractiveMap = r.InteractiveMap
+	m.CanonicalURL = r.CanonicalURL
+	m.URL = r.URL
+	m.NavContext = r.NavContext
+	m.AnalyticsCategory = r.AnalyticsCategory
+	m.AdvertisingCategory = r.AdvertisingCategory
+
+	return nil
+}
+
+// HTMLContent represents a content object that contains a raw HTML payload
+type HTMLContent struct {
+	Type                ItemType `json:"type"`
+	ContentID           int      `json:"content_id"`
+	PublicationDate     string   `json:"publication_date"`
+	Code                string   `json:"code"`
+	TeaserTitle         string   `json:"teaser_title"`
+	NavContext          []string `json:"navigation_context"`
+	AnalyticsCategory   string   `json:"analytics_category"`
+	AdvertisingCategory string   `json:"advertising_category"`
+	StationName         string   `json:"station_name"`
+}
+
+func (h *HTMLContent) GetType() ItemType {
+	return HTMLType
+}
+
+func (h *HTMLContent) GetContentID() int {
+	return h.ContentID
+}
+
+func (h *HTMLContent) GetTeaserTitle() string {
+	return h.TeaserTitle
+}
+
+func (h *HTMLContent) GetTeaserText() string {
+	return ""
+}
+
+func (h *HTMLContent) GetPublicationDate() string {
+	return h.PublicationDate
+}
+
+func (h *HTMLContent) Unmarshal(r *Receiver) error {
+	h.Type = r.Type
+	h.ContentID = r.ContentID
+	h.PublicationDate = r.PublicationDate
+	h.Code = r.Code
+	h.TeaserTitle = getTeaserTitle(r)
+	h.NavContext = r.NavContext
+	h.AnalyticsCategory = r.AnalyticsCategory
+	h.AdvertisingCategory = r.AdvertisingCategory
+
+	return nil
+}
+
+// Settings represents a collection of settings
+type Settings struct {
+	ContentID   int               `json:"content_id"`
+	Settings    map[string]string `json:"settings"`
+	StationName string            `json:"station_name"`
+}
+
+func (s *Settings) GetType() ItemType {
+	return SettingsType
+}
+
+func (s *Settings) GetContentID() int {
+	return s.ContentID
+}
+
+func (s *Settings) GetTeaserTitle() string {
+	return ""
+}
+
+func (s *Settings) GetTeaserText() string {
+	return ""
+}
+
+func (s *Settings) GetPublicationDate() string {
+	return ""
+}
+
+func (s *Settings) Unmarshal(r *Receiver) error {
+	s.ContentID = r.ContentID
+	if len(r.Settings) > 0 {
+		s.Settings = r.Settings[0]
+	}
+
+	return nil
+}
+
+// Teaser represents ... something
+type Teaser struct {
+	Type                ItemType `json:"type"`
+	ContentID           int      `json:"content_id"`
+	Title               string   `json:"title"`
+	TeaserTitle         string   `json:"teaser_title"`
+	TeaserText          string   `json:"teaser_text"`
+	PublicationDate     string   `json:"publication_date"`
+	Authors             []Person `json:"author_objects"`
+	Media               []Item   `json:"media"`
+	NavContext          []string `json:"navigation_context"`
+	AnalyticsCategory   string   `json:"analytics_category"`
+	AdvertisingCategory string   `json:"advertising_category"`
+	Target              Item     `json:"target"`
+	StationName         string   `json:"station_name"`
+}
+
+func (t *Teaser) GetType() ItemType {
+	return TeaserType
+}
+
+func (t *Teaser) GetContentID() int {
+	return t.ContentID
+}
+
+func (t *Teaser) GetTeaserTitle() string {
+	return t.TeaserTitle
+}
+
+func (t *Teaser) GetTeaserText() string {
+	return t.TeaserText
+}
+
+func (t *Teaser) GetPublicationDate() string {
+	return t.PublicationDate
+}
+
+func (t *Teaser) Unmarshal(r *Receiver) error {
+	t.Type = r.Type
+	t.ContentID = r.ContentID
+	t.Title = r.Title
+	t.TeaserTitle = getTeaserTitle(r)
+	t.TeaserText = r.TeaserText
+	t.PublicationDate = r.PublicationDate
+	t.Authors = r.Authors
+	t.NavContext = r.NavContext
+	t.AnalyticsCategory = r.AnalyticsCategory
+	t.AdvertisingCategory = r.AdvertisingCategory
+
+	if r.Target == nil {
+		return fmt.Errorf("teaser object missing target %d", t.ContentID)
+	}
+
+	if target, err := r.Target.Unmarshal(); err != nil {
+		return err
+	} else {
+		t.Target = target
+	}
+
+	media, err := unmarshalItems(r.Media)
+	t.Media = media
+
+	return err
+}

--- a/datamap/receiver_test.go
+++ b/datamap/receiver_test.go
@@ -1,0 +1,116 @@
+package datamap
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_UnmarshalBareBase(t *testing.T) {
+	//arrange
+	base := &bareBase{}
+	receiver := Receiver{
+		Type:                ArticleType,
+		Hash:                "hash",
+		ContentID:           1,
+		ContentName:         "content",
+		Title:               "Title",
+		CreationDate:        "2015-01-01T00:00:00-03:00",
+		PublicationDate:     "2016-01-01T00:00:00-03:00",
+		NavContext:          []string{"home", "article"},
+		ValidFrom:           "2017-01-01T00:00:00-03:00",
+		ValidTo:             "2018-01-01T00:00:00-03:00",
+		AnalyticsCategory:   "item",
+		AdvertisingCategory: "item_adv",
+	}
+
+	//act
+	base.unmarshalBareBase(&receiver)
+
+	//assert
+	assert.ObjectsAreEqual(receiver.Type, base.Type)
+	assert.ObjectsAreEqual(receiver.Hash, base.Hash)
+	assert.ObjectsAreEqual(receiver.ContentID, base.ContentID)
+	assert.ObjectsAreEqual(receiver.ContentName, base.ContentName)
+	assert.ObjectsAreEqual(receiver.Title, base.Title)
+	assert.ObjectsAreEqual(receiver.CreationDate, base.CreationDate)
+	assert.ObjectsAreEqual(receiver.PublicationDate, base.PublicationDate)
+	assert.ObjectsAreEqual(receiver.NavContext, base.NavContext)
+	assert.ObjectsAreEqual(receiver.ValidFrom, base.ValidFrom)
+	assert.ObjectsAreEqual(receiver.ValidTo, base.ValidTo)
+	assert.ObjectsAreEqual(receiver.AnalyticsCategory, base.AnalyticsCategory)
+	assert.ObjectsAreEqual(receiver.AdvertisingCategory, base.AdvertisingCategory)
+}
+
+func Test_UnmarshalFullBase(t *testing.T) {
+	//arrange
+	base := &fullBase{}
+	receiver := Receiver{
+		Type:                ArticleType,
+		Hash:                "hash",
+		ContentID:           1,
+		ContentName:         "content",
+		Title:               "Title",
+		CreationDate:        "2015-01-01T00:00:00-03:00",
+		PublicationDate:     "2016-01-01T00:00:00-03:00",
+		NavContext:          []string{"home", "article"},
+		ValidFrom:           "2017-01-01T00:00:00-03:00",
+		ValidTo:             "2018-01-01T00:00:00-03:00",
+		AnalyticsCategory:   "item",
+		AdvertisingCategory: "item_adv",
+		TeaserTitle:         "teaser title",
+		TeaserText:          "teaser text",
+		TeaserImage:         "http://teaser.com/image",
+		Author:              "The Author",
+		Authors: []Person{
+			{
+				FullName:      "Full Name Smith",
+				Email:         "full@name.smith",
+				Bio:           "Smith was born, then lived and died.",
+				Photo:         Image{},
+				FacebookURL:   "https://facebook.com",
+				GooglePlusURL: "https://plus.google.com",
+				TwitterURL:    "https://twitter.com",
+			},
+		},
+		EditorialComment: "I'm here to edit comments",
+		Copyright:        "Everything was copied in the right way",
+		Copyrights:       []Copyright{},
+		Media: []Receiver{
+			{
+				Type: "VIDEO",
+			},
+			{
+				Type: "IMAGE",
+			},
+		},
+		CanonicalURL:      "http://url.com/index.html",
+		URL:               "http://url.com/index.html?orderby=date&view=list",
+		Categories:        nil,
+		Struct:            nil,
+		CommentingEnabled: true, //important to be true to test so it's not mistaken by the default value
+		NoFollow:          true,
+		NotSearchable:     true,
+		Period:            "a month",
+		Keywords:          "jail,locker,door,chest,keychain",
+	}
+
+	//act
+	err := base.unmarshalFullBase(&receiver)
+
+	//assert
+	assert.Nil(t, err)
+	assert.ObjectsAreEqual(receiver.Type, base.Type)
+	assert.ObjectsAreEqual(receiver.Hash, base.Hash)
+	assert.ObjectsAreEqual(receiver.ContentID, base.ContentID)
+	assert.ObjectsAreEqual(receiver.ContentName, base.ContentName)
+	assert.ObjectsAreEqual(receiver.Title, base.Title)
+	assert.ObjectsAreEqual(receiver.CreationDate, base.CreationDate)
+	assert.ObjectsAreEqual(receiver.PublicationDate, base.PublicationDate)
+	assert.ObjectsAreEqual(receiver.NavContext, base.NavContext)
+	assert.ObjectsAreEqual(receiver.ValidFrom, base.ValidFrom)
+	assert.ObjectsAreEqual(receiver.ValidTo, base.ValidTo)
+	assert.ObjectsAreEqual(receiver.AnalyticsCategory, base.AnalyticsCategory)
+	assert.ObjectsAreEqual(receiver.AdvertisingCategory, base.AdvertisingCategory)
+	assert.ObjectsAreEqualValues(receiver, base)
+}

--- a/datamap/struct-data-model
+++ b/datamap/struct-data-model
@@ -1,0 +1,129 @@
+	-advertising_category string
+	-analytics_category string
+	-article_text
+	-author string
+	-author_location
+	-author_objects []
+	-backupUrl string
+	-biography string
+	-canonical_url string
+	-caption string
+	-categories []
+	-children
+	-collection_name
+	-commenting_enabled bool
+	-commenting_id //comment_id??
+	-content_id int
+	-content_name string
+	-copyright string
+	-copyright_objects []
+	-creation_date string //date
+	-dynamic
+	-editorial_comment string
+	-email string
+	-external_content
+	-external_id string
+	-facebook_url string
+	-flavors []
+		bitrate int
+		codec string
+		duration int
+		file_size int
+		height int
+		tags string //comma separated
+		url string
+		video_type string //extension?
+		width int
+	-full_name string
+	-google_plus_url string
+	-hash string
+	-identifier
+	-items []
+		content_id
+		creation_date
+		hash
+		publication_date
+		teaser_image
+		teaser_text
+		teaser_title
+		type
+		-urls []
+			height
+			mime
+			url
+			version
+			width
+		valid_from
+		valid_to
+	-keywords string //comma separated
+	-livestream {}
+		-content_id int
+		-creation_date string
+		-hash string
+		-publication_date string
+		-teaser_image string
+		-teaser_text string
+		-teaser_title string
+		-type string
+		-valid_from string
+		-valid_to string
+	-link_text
+	-m3u8 string //url
+	-media []
+		content_id
+		creation_date
+		hash
+		publication_date
+		teaser_image
+		teaser_text
+		teaser_title
+		type
+		urls [] //same as above
+		valid_from
+		valid_to
+	-navigation_context [] string
+	-no_follow bool
+	-not_searchable bool
+	-pasword string
+	-period string
+	-photo []
+		content_id int
+		hash string
+		publication_date int //!!! yep, it's a number
+		teaser_image string
+		teaser_text string
+		teaser_title string
+		type string
+		urls [] //same as above
+	-primaryEncoder string
+	-primaryUrl string
+	-publication_date string
+	-related_media []
+	-secondaryEncoder string
+	-settings
+	-sharing_enabled bool
+	-show_ads bool
+	-start_index
+	-streamName string
+	-streamTranscoded bool
+	-struct []
+		creation_date
+		publication_date
+		valid_from
+		valid_to
+	-subheadline string
+	-teaser_image string
+	-teaser_text string
+	-teaser_title string
+	-text string
+	-title string
+	-twitter_url string
+	-transformed_external_content
+	-transformed_type
+	-total_count
+	-type string
+	-url string
+	-userName string
+	valid_from string //date
+	valid_to string //date
+	view_type

--- a/datamap/util.go
+++ b/datamap/util.go
@@ -1,0 +1,42 @@
+package datamap
+
+import l5g "github.com/neocortical/log5go"
+
+var log = l5g.Logger(l5g.LogAll)
+
+func getTeaserTitle(r *Receiver) (title string) {
+	title = r.TeaserTitle
+	if title == "" {
+		title = r.Title
+	}
+	return
+}
+
+func unmarshalItems(r []Receiver) (items []Item, err error) {
+	items = []Item{}
+
+	for _, rInner := range r {
+		if i, err := rInner.Unmarshal(); err != nil {
+			log.Warn("error unmarshalling sub-object: %v", err)
+		} else {
+			items = append(items, i)
+		}
+	}
+
+	return
+}
+
+func unmarshalCollections(r []Receiver) ([]Collection, error) {
+	collections := []Collection{}
+
+	for _, rInner := range r {
+		c := Collection{}
+		if err := c.Unmarshal(&rInner); err != nil {
+			log.Warn("error unmarshalling collection: %v", err)
+			return nil, err
+		}
+		collections = append(collections, c)
+	}
+
+	return collections, nil
+}

--- a/datamap/video.go
+++ b/datamap/video.go
@@ -1,0 +1,63 @@
+package datamap
+
+// Video represents an IB video
+type Video struct {
+	fullBase
+
+	ExternalID     string        `json:"external_id"`
+	Caption        string        `json:"caption"`
+	Subheadline    string        `json:"subheadline"`
+	Flavors        []VideoFlavor `json:"flavors"`
+	StreamURL      string        `json:"m3u8"`
+	ShowAds        bool          `json:"show_ads"`
+	SharingEnabled bool          `json:"sharing_enabled"`
+}
+
+func (v *Video) GetType() ItemType {
+	return VideoType
+}
+
+func (v *Video) GetContentID() int {
+	return v.ContentID
+}
+
+func (v *Video) GetTeaserTitle() string {
+	return v.TeaserTitle
+}
+
+func (v *Video) GetTeaserText() string {
+	return v.TeaserText
+}
+
+func (v *Video) GetPublicationDate() string {
+	return v.PublicationDate
+}
+
+func (v *Video) Unmarshal(r *Receiver) error {
+	if err := v.unmarshalFullBase(r); err != nil {
+		return err
+	}
+
+	v.ExternalID = r.ExternalID
+	v.Caption = r.Caption
+	v.Subheadline = r.Subheadline
+	v.Flavors = r.Flavors
+	v.StreamURL = r.StreamURL
+	v.ShowAds = r.ShowAds
+	v.SharingEnabled = r.SharingEnabled
+
+	return nil
+}
+
+// VideoFlavor represents a flavor (i.e. resolution) of an IB Video
+type VideoFlavor struct {
+	Format   string `json:"video_type"`
+	URL      string `json:"url"`
+	Bitrate  int    `json:"bitrate"`
+	Duration int    `json:"duration"`
+	FileSize int    `json:"file_size"`
+	Codec    string `json:"codec"`
+	Width    int    `json:"width"`
+	Height   int    `json:"height"`
+	Tags     string `json:"tags"`
+}

--- a/model.go
+++ b/model.go
@@ -98,7 +98,7 @@ type Receiver struct {
 	ExternalID          string              `json:"external_id"`
 	ShowAds             bool                `json:"show_ads"`
 	Target              *Receiver           `json:"target"`
-	Captions            map[string]string      `json:"captions"` // not from IB, but needed for UnmarshalReceiver()
+	Captions            map[string]string   `json:"captions"` // not from IB, but needed for UnmarshalReceiver()
 }
 
 // Item is the base type of all items. It is not used outside the IB package, as
@@ -157,7 +157,7 @@ func (c *Collection) GetStationName() string {
 	return c.StationName
 }
 
-func (c *Collection) SetStationName(name string)  {
+func (c *Collection) SetStationName(name string) {
 	c.StationName = name
 }
 
@@ -208,7 +208,7 @@ func (a *Article) GetStationName() string {
 	return a.StationName
 }
 
-func (a *Article) SetStationName(name string)  {
+func (a *Article) SetStationName(name string) {
 	a.StationName = name
 }
 
@@ -258,7 +258,7 @@ func (v *Video) GetStationName() string {
 	return v.StationName
 }
 
-func (v *Video) SetStationName(name string)  {
+func (v *Video) SetStationName(name string) {
 	v.StationName = name
 }
 
@@ -324,7 +324,7 @@ func (i *Image) GetStationName() string {
 	return i.StationName
 }
 
-func (i *Image) SetStationName(name string)  {
+func (i *Image) SetStationName(name string) {
 	i.StationName = name
 }
 
@@ -339,25 +339,25 @@ type ImageURL struct {
 
 // Gallery represents an image gallery
 type Gallery struct {
-	Type                ItemType       `json:"type"`
-	ContentID           int            `json:"content_id"`
-	TeaserTitle         string         `json:"teaser_title"`
-	TeaserText          string         `json:"teaser_text"`
-	TeaserImage         string         `json:"teaser_image"`
-	PublicationDate     int64          `json:"publication_date"`
-	Authors             []Person       `json:"author_objects"`
-	Keywords            string         `json:"keywords"`
-	Title               string         `json:"title"`
-	Subheadline         string         `json:"subheadline"`
-	Media               []Item         `json:"media"`
-	Items               []Item         `json:"items"`
+	Type                ItemType          `json:"type"`
+	ContentID           int               `json:"content_id"`
+	TeaserTitle         string            `json:"teaser_title"`
+	TeaserText          string            `json:"teaser_text"`
+	TeaserImage         string            `json:"teaser_image"`
+	PublicationDate     int64             `json:"publication_date"`
+	Authors             []Person          `json:"author_objects"`
+	Keywords            string            `json:"keywords"`
+	Title               string            `json:"title"`
+	Subheadline         string            `json:"subheadline"`
+	Media               []Item            `json:"media"`
+	Items               []Item            `json:"items"`
 	Captions            map[string]string `json:"captions"`
-	CanonicalURL        string         `json:"canonical_url"`
-	URL                 string         `json:"url"`
-	NavContext          []string       `json:"navigation_context"`
-	AnalyticsCategory   string         `json:"analytics_category"`
-	AdvertisingCategory string         `json:"advertising_category"`
-	StationName         string         `json:"station_name"`
+	CanonicalURL        string            `json:"canonical_url"`
+	URL                 string            `json:"url"`
+	NavContext          []string          `json:"navigation_context"`
+	AnalyticsCategory   string            `json:"analytics_category"`
+	AdvertisingCategory string            `json:"advertising_category"`
+	StationName         string            `json:"station_name"`
 }
 
 func (g *Gallery) GetType() ItemType {
@@ -384,7 +384,7 @@ func (g *Gallery) GetStationName() string {
 	return g.StationName
 }
 
-func (g *Gallery) SetStationName(name string)  {
+func (g *Gallery) SetStationName(name string) {
 	g.StationName = name
 }
 
@@ -432,7 +432,7 @@ func (a *Audio) GetStationName() string {
 	return a.StationName
 }
 
-func (a *Audio) SetStationName(name string)  {
+func (a *Audio) SetStationName(name string) {
 	a.StationName = name
 }
 
@@ -482,7 +482,7 @@ func (l *Livevideo) GetStationName() string {
 	return l.StationName
 }
 
-func (l *Livevideo) SetStationName(name string)  {
+func (l *Livevideo) SetStationName(name string) {
 	l.StationName = name
 }
 
@@ -529,7 +529,7 @@ func (m *Map) GetStationName() string {
 	return m.StationName
 }
 
-func (m *Map) SetStationName(name string)  {
+func (m *Map) SetStationName(name string) {
 	m.StationName = name
 }
 
@@ -568,7 +568,7 @@ func (e *ExternalContent) GetStationName() string {
 	return e.StationName
 }
 
-func (e *ExternalContent) SetStationName(name string)  {
+func (e *ExternalContent) SetStationName(name string) {
 	e.StationName = name
 }
 
@@ -582,7 +582,7 @@ type ExternalLink struct {
 	CanonicalURL    string   `json:"canonical_url"`
 	URL             string   `json:"url"`
 	Media           []Item   `json:"media"`
-	StationName     string    `json:"station_name"`
+	StationName     string   `json:"station_name"`
 }
 
 func (e *ExternalLink) GetType() ItemType {
@@ -609,7 +609,7 @@ func (e *ExternalLink) GetStationName() string {
 	return e.StationName
 }
 
-func (e ExternalLink) SetStationName(name string)  {
+func (e ExternalLink) SetStationName(name string) {
 	e.StationName = name
 }
 
@@ -619,6 +619,8 @@ type HTMLContent struct {
 	ContentID           int      `json:"content_id"`
 	PublicationDate     int64    `json:"publication_date"`
 	Code                string   `json:"code"`
+	URL                 string   `json:"url"`
+	TeaserTitle         string   `json:"teaser_title"`
 	NavContext          []string `json:"navigation_context"`
 	AnalyticsCategory   string   `json:"analytics_category"`
 	AdvertisingCategory string   `json:"advertising_category"`
@@ -634,7 +636,7 @@ func (h *HTMLContent) GetContentID() int {
 }
 
 func (h *HTMLContent) GetTeaserTitle() string {
-	return ""
+	return h.TeaserTitle
 }
 
 func (h *HTMLContent) GetTeaserText() string {
@@ -649,7 +651,7 @@ func (h *HTMLContent) GetStationName() string {
 	return h.StationName
 }
 
-func (h *HTMLContent) SetStationName(name string)  {
+func (h *HTMLContent) SetStationName(name string) {
 	h.StationName = name
 }
 
@@ -702,7 +704,7 @@ func (p *Person) GetStationName() string {
 	return p.StationName
 }
 
-func (p *Person) SetStationName(name string)  {
+func (p *Person) SetStationName(name string) {
 	p.StationName = name
 }
 
@@ -735,9 +737,9 @@ type ClsInstitution struct {
 
 // Settings represents a collection of settings
 type Settings struct {
-	ContentID     int               `json:"content_id"`
-	Settings      map[string]string `json:"settings"`
-	StationName   string            `json:"station_name"`
+	ContentID   int               `json:"content_id"`
+	Settings    map[string]string `json:"settings"`
+	StationName string            `json:"station_name"`
 }
 
 func (c *Settings) GetType() ItemType {
@@ -764,7 +766,7 @@ func (c *Settings) GetStationName() string {
 	return c.StationName
 }
 
-func (c *Settings) SetStationName(name string)  {
+func (c *Settings) SetStationName(name string) {
 	c.StationName = name
 }
 
@@ -809,6 +811,6 @@ func (t *Teaser) GetStationName() string {
 	return t.StationName
 }
 
-func (t *Teaser) SetStationName(name string)  {
+func (t *Teaser) SetStationName(name string) {
 	t.StationName = name
 }


### PR DESCRIPTION
### Migration Data

I looked over every JSON data structure in the `testdata` folder and replicate its structure in go structs merging it with the uncommon fields already existed in the API's structures. Those fields are always at the very end of each struct bellow a comment of compatibility.
### "Inheritance"

I used the is-a approach in the structs by setting the anonymous field, instead of copying over every common field everywhere. In the API models it was not a big issue, but here it is 'cause the number of fields. And it raised me a question: Why not set all the default behavior of methods in a super structure shared among everyone (to implement the Item interface) and just shadow it when a specific struct gets a different logic? Is that a bad practice? I tried to do some search around it and couldn't find anything claiming this as a bad practice, and you benefit with no repeated code everywhere. In the current code, I could do that in the `bareBase` and `fullBase` structs with no problem.
### Splitting in Multiple Files

Reading through the `model.go` to find the structs was a bit hard for me, so I decided to separate the data in another package. I didn't break anything with the current API's implementation, since all my code is new code (and doesn't change any other part of the repo)

I'm about to implement a conversor manager, but before that I want to check if what I did is pointing to a good direction.
